### PR TITLE
chore: added automatic title prefix

### DIFF
--- a/.github/workflows/pr-title-labeler.yml
+++ b/.github/workflows/pr-title-labeler.yml
@@ -89,24 +89,24 @@ jobs:
             // Update PR title with prefix
             const selectedLabel = [...shouldHaveLabels][0];
             if (selectedLabel) {
-              const prefix = titlePrefixMappings[selectedLabel];
+              const prefix = titlePrefixMappings[selectedLabel].toLowerCase();
               let currentTitle = context.payload.pull_request.title;
               
               // Check if current title has any prefix (including non-standard ones)
-              const prefixMatch = currentTitle.match(/^([a-zA-Z]+):\s*/);
+              const prefixMatch = currentTitle.match(/^([a-zA-Z]+):\s*(.*)/);
               
               if (prefixMatch) {
-                const currentPrefix = prefixMatch[1].toLowerCase();
+                const titleContent = prefixMatch[2];
                 // Only update if current prefix is not the correct one
+                const currentPrefix = prefixMatch[1].toLowerCase();
                 if (!validPrefixes.includes(currentPrefix) || currentPrefix !== prefix) {
-                  currentTitle = currentTitle.replace(/^[a-zA-Z]+:\s*/, '');
-                  const newTitle = `${prefix}: ${currentTitle}`;
+                  const newTitle = `${prefix}: ${titleContent}`;
                   
                   await github.rest.pulls.update({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     pull_number: context.payload.pull_request.number,
-                    title: newTitle.toLowerCase()
+                    title: newTitle
                   });
                 }
               } else {
@@ -117,7 +117,7 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   pull_number: context.payload.pull_request.number,
-                  title: newTitle.toLowerCase()
+                  title: newTitle
                 });
               }
             }

--- a/.github/workflows/pr-title-labeler.yml
+++ b/.github/workflows/pr-title-labeler.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
 
-      - name: Update PR labels
+      - name: Update PR labels and title
         uses: actions/github-script@v7.0.1
         with:
           script: |
@@ -27,6 +27,19 @@ jobs:
               'Documentation update': 'Documentation',
               'Chore': 'Chore'
             };
+
+            const titlePrefixMappings = {
+              'Bug': 'fix',
+              'Feature': 'feat',
+              'UI/UX': 'ui',
+              'Data Processing': 'data',
+              'Optimisation': 'perf',
+              'Security': 'security',
+              'Documentation': 'docs',
+              'Chore': 'chore'
+            };
+
+            const validPrefixes = Object.values(titlePrefixMappings);
            
             // Determine which labels should be present
             for (const [text, label] of Object.entries(labelMappings)) {
@@ -71,4 +84,40 @@ jobs:
                 issue_number: context.payload.pull_request.number,
                 labels: labelsToAdd
               });
+            }
+
+            // Update PR title with prefix
+            const selectedLabel = [...shouldHaveLabels][0];
+            if (selectedLabel) {
+              const prefix = titlePrefixMappings[selectedLabel];
+              let currentTitle = context.payload.pull_request.title;
+              
+              // Check if current title has any prefix (including non-standard ones)
+              const prefixMatch = currentTitle.match(/^([a-zA-Z]+):\s*/);
+              
+              if (prefixMatch) {
+                const currentPrefix = prefixMatch[1].toLowerCase();
+                // Only update if current prefix is not the correct one
+                if (!validPrefixes.includes(currentPrefix) || currentPrefix !== prefix) {
+                  currentTitle = currentTitle.replace(/^[a-zA-Z]+:\s*/, '');
+                  const newTitle = `${prefix}: ${currentTitle}`;
+                  
+                  await github.rest.pulls.update({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: context.payload.pull_request.number,
+                    title: newTitle.toLowerCase()
+                  });
+                }
+              } else {
+                // No prefix exists, add new one
+                const newTitle = `${prefix}: ${currentTitle}`;
+                
+                await github.rest.pulls.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.payload.pull_request.number,
+                  title: newTitle.toLowerCase()
+                });
+              }
             }

--- a/src/resources/CHANGELOG.md
+++ b/src/resources/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed key index errors in mobile dropdown and header
 - Enhanced the changelog checker to check for bot PRs including removal of changelog labels for bot PRs
 - Added CodeRabbit config with auto review for bot PRs
+- Enhanced automatic PR labeler to also do automatic PR title prefixing
 
 ---
 


### PR DESCRIPTION
## Description

Enhanced the PR labeler workflow to now include adding a prefix to the title of the PR

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Weather data processing
- [ ] Optimisation
- [ ] Security
- [ ] Documentation update
- [x] Chore
- [ ] Other (please describe)

## Changes Made

- Enhanced PR labeler to also do title prefixes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pull request management now automatically updates titles with a corresponding prefix when labels are applied, ensuring consistency and standardisation.
  
- **Documentation**
  - The changelog has been updated (version 1.0.8) to reflect the new automatic title prefixing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->