### PR TITLE
fix: Fixed bug not showing night icons in Single 3 Hour Page

### DIFF
--- a/src/components/dailyWeather.jsx
+++ b/src/components/dailyWeather.jsx
@@ -1,6 +1,6 @@
 import {useEffect, useState, useMemo, memo } from 'react';
 import axios from "axios";
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { Header } from './utils/header';
 import { Footer } from './utils/footer';
 import { WeatherIcons, WindDirection, VisibilityDesc, WindForce, TimeZoneShow, SunriseSunsetTimes } from './utils/weatherVariables';
@@ -13,6 +13,8 @@ export const DailyWeatherData = memo(() => {
   const [ weather, setWeather ] = useState([]);
   const [ times, setTimes ] = useState([]);
   const [ error, setError ] = useState(null);
+
+  const navigate = useNavigate();
 
   useEffect(() => {
     document.title = "Worther - Daily Weather - " + (location.name || "");
@@ -197,7 +199,7 @@ export const DailyWeatherData = memo(() => {
               </>
             }
           </div>
-          <button className="rounded-md h-8 text-xl my-16 font-bold w-24 mx-auto border" onClick={() => window.history.back()}>Go Back</button>
+          <button className="rounded-md h-8 text-xl my-16 font-bold w-24 mx-auto border" onClick={() => navigate(-1)}>Go Back</button>
       </div>
       <Footer />
     </div>

--- a/src/components/utils/weatherVariables.jsx
+++ b/src/components/utils/weatherVariables.jsx
@@ -100,9 +100,9 @@ const weatherIconsMap = {
 export const WeatherIcons = memo((props) => {
   const currentHourConversion = useMemo(() => {
     const d = new Date();
-    const baseHour = props.page === 'single' ? d.getHours() : props.hourConversion;
+    const baseHour = props.hourConversion || d.getHours();
     return Math.round(((baseHour * 3600 + d.getTimezoneOffset() * 60) + props.timeZone) / 3600);
-  }, [props.page, props.timeZone, props.hourConversion]);
+  }, [props.timeZone, props.hourConversion]);
   
   const size = useMemo(() => 
     props.page === 'single' ? 200 : props.page === 'multiple' ? 50 : 85, 
@@ -324,6 +324,7 @@ export const ShowWeather = memo((props) => {
           timeZone={props.timeZone}
           sunriseHour={props.localSunriseSunsetTimes?.sunriseHour}
           sunsetHour={props.localSunriseSunsetTimes?.sunsetHour}
+          hourConversion={props.hourConversion}
           page="single"
         />
       </section>

--- a/src/resources/CHANGELOG.md
+++ b/src/resources/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Fixed bug with icon not showing as night on Single 3 Hour Forecast page
 - Changed fixes to resolves in PR template
 - Bump react & react-dom from 19.0.0 to 19.1.0
+- Actually fixed bug with icon not showing as night on Single 3 Hour Forecast page
 
 ---
 


### PR DESCRIPTION
## Description

Fixed bug not showing night icons in Single 3 Hour Page, and some performance fixes

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Weather data processing
- [x] Optimisation
- [ ] Security
- [ ] Documentation update
- [ ] Chore
- [ ] Other (please describe)

## Changes Made

- Removed the use of page logic to calculate hours
- Changed go back button on daily weather page to use useNavigate instead

## Testing
<!-- Describe how you tested these changes -->
- [x] Tested weather data fetching
- [x] Verified UI updates
- [x] Checked error handling
- [x] Tested on multiple browsers/devices

## Screenshots
<!-- If applicable, add screenshots or GIFs -->

## Additional Notes
<!-- Any additional information that reviewers should know -->

## Checklist
- [x] Code follows project style guidelines
- [x] API keys and sensitive data are properly protected
- [x] Weather data validation is in place
- [x] Error handling is implemented
- [x] Documentation has been updated
- [x] Tests have been added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced navigation flow by updating the back button action for a smoother experience.
  - Improved weather display logic to ensure icons accurately reflect time-based changes.
  
- **Bug Fixes**
  - Corrected an issue with night-time icons not displaying properly on the forecast page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->