### PR TITLE
ui: Fix for shifting layout in 3 Hour Forecast

### DIFF
--- a/src/components/3HourForecastData.jsx
+++ b/src/components/3HourForecastData.jsx
@@ -118,9 +118,9 @@ export const ThreeHourForecastData = memo(() => {
                       aria-label={`Weather forecast for ${day} at ${(hourConversion > 23) ? String(hourConversion - 24).padStart(2, '0') : (hourConversion < 0) ? (hourConversion + 24) : String(hourConversion).padStart(2, '0')}:${weather.timeNormalMinutes}, ${weather.description}`}
                       key={weather.index} 
                       onClick={(e) => handleSubmit(e, weather.index)} 
-                      className='duration-300 hover:cursor-pointer hover:text-4xl hover:bg-cyan-800 lg:flex-row flex flex-col border-b-2 text-white h-fit w-screen'
+                      className='duration-300 hover:cursor-pointer hover:bg-cyan-800 lg:grid lg:grid-cols-7 lg:gap-2 lg:items-center flex flex-col border-b-2 text-white h-fit w-screen py-px'
                     >
-                      <span className="lg:ml-5 mx-auto mt-5 lg:my-auto lg:mr-7">
+                      <div className="lg:justify-self-center mx-auto">
                         <WeatherIcons 
                           mainWeather={weather.mainWeather} 
                           windSpeed={weather.windSpeed} 
@@ -131,16 +131,28 @@ export const ThreeHourForecastData = memo(() => {
                           hourConversion={hourConversion} 
                           page={isDesktopView ? 'multiple' : 'multiple-mobile'}
                         />
-                      </span>
-                      <span className='lg:my-3.5 font-bold text-xl lg:mr-10 mt-5 mx-auto'>{(hourConversion > 23) ? String(hourConversion - 24).padStart(2, '0') : (hourConversion < 0) ? (hourConversion + 24) : String(hourConversion).padStart(2, '0')}:{weather.timeNormalMinutes} ({<TimeZoneShow timeZone={location.timeZone}/>})</span>
-                      <span className='lg:my-3 lg:mr-10 font-bold text-2xl mt-5 mx-auto'>{weather.description.toUpperCase()}</span>
-                      <span className='lg:my-3 lg:mr-9 text-xl mt-5 mx-auto'>Temp: {Math.round(weather.temperature)}°C</span>
-                      <span className='lg:my-3 lg:mr-9 text-xl mt-5 mx-auto'>Wind Speed: {weather.windSpeed} m/s ({<WindForce windSpeed={weather.windSpeed} />})&ensp; Wind Direction: {<WindDirection windDegrees={weather.windDegrees}/>} @ {weather.windDegrees}°</span>
-                      <span className='lg:my-3 lg:mr-9 text-xl mt-5 mx-auto'>Precipitation: {Math.round(weather.precipitation)}%</span>
-                      <span className='lg:my-3 lg:mr-9 text-xl my-5 mx-auto'>Visibility: {(weather.visibility >= 1000) ?
-                        (weather.visibility / 1000) + 'km' :
-                        (weather.visibility) + 'm'} ({<VisibilityDesc visibility={weather.visibility}/>})
-                      </span>
+                      </div>
+                      <div className='font-bold text-xl mx-auto lg:justify-self-center'>
+                        {(hourConversion > 23) ? String(hourConversion - 24).padStart(2, '0') : (hourConversion < 0) ? (hourConversion + 24) : String(hourConversion).padStart(2, '0')}:{weather.timeNormalMinutes} ({<TimeZoneShow timeZone={location.timeZone}/>})
+                      </div>
+                      <div className='font-bold text-2xl mx-auto lg:justify-self-center mt-3 lg:mt-0'>
+                        {weather.description.toUpperCase()}
+                      </div>
+                      <div className='text-xl mx-auto lg:justify-self-center mt-3 lg:mt-0'>
+                        Temp: {Math.round(weather.temperature)}°C
+                      </div>
+                      <div className='text-xl mx-auto lg:justify-self-center mt-3 lg:mt-0'>
+                        Wind Speed: {weather.windSpeed} m/s ({<WindForce windSpeed={weather.windSpeed} />})
+                        <div className="lg:mt-1">Direction: {<WindDirection windDegrees={weather.windDegrees}/>} @ {weather.windDegrees}°</div>
+                      </div>
+                      <div className='text-xl mx-auto lg:justify-self-center mt-3 lg:mt-0'>
+                        Precipitation: {Math.round(weather.precipitation)}%
+                      </div>
+                      <div className='text-xl mx-auto lg:justify-self-center mt-3 lg:mt-0 mb-3 lg:mb-0'>
+                        Visibility: {(weather.visibility >= 1000) ?
+                          (weather.visibility / 1000) + 'km' :
+                          (weather.visibility) + 'm'} ({<VisibilityDesc visibility={weather.visibility}/>})
+                      </div>
                     </button>
                   );
                 })}

--- a/src/components/3HourForecastData.jsx
+++ b/src/components/3HourForecastData.jsx
@@ -143,7 +143,7 @@ export const ThreeHourForecastData = memo(() => {
                       </div>
                       <div className='text-xl mx-auto lg:justify-self-center mt-3 lg:mt-0'>
                         Wind Speed: {weather.windSpeed} m/s ({<WindForce windSpeed={weather.windSpeed} />})
-                        <div className="lg:mt-1">Direction: {<WindDirection windDegrees={weather.windDegrees}/>} @ {weather.windDegrees}°</div>
+                        <div className="lg:mt-1 lg:pl-2">Direction: {<WindDirection windDegrees={weather.windDegrees}/>} @ {weather.windDegrees}°</div>
                       </div>
                       <div className='text-xl mx-auto lg:justify-self-center mt-3 lg:mt-0'>
                         Precipitation: {Math.round(weather.precipitation)}%

--- a/src/resources/CHANGELOG.md
+++ b/src/resources/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Changed fixes to resolves in PR template
 - Bump react & react-dom from 19.0.0 to 19.1.0
 - Actually fixed bug with icon not showing as night on Single 3 Hour Forecast page
+- Fixed alignment of divs in 3 Hour Forecast page
 
 ---
 

--- a/src/resources/CHANGELOG.md
+++ b/src/resources/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Changed fixes to resolves in PR template
 - Bump react & react-dom from 19.0.0 to 19.1.0
 - Actually fixed bug with icon not showing as night on Single 3 Hour Forecast page
-- Fixed alignment of divs in 3 Hour Forecast page
+- Fixed alignment of divs in 3-Hour Forecast page
 
 ---
 


### PR DESCRIPTION
## Description

Made the 3 Hour Forecast more like grid boxes to remove the shifting layout it had with not everything aligned

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] UI/UX improvement
- [ ] Weather data processing
- [ ] Optimisation
- [ ] Security
- [ ] Documentation update
- [ ] Chore
- [ ] Other (please describe)

## Changes Made

- Adjusted CSS of 3 Hour Forecast display

## Testing
<!-- Describe how you tested these changes -->
- [x] Tested weather data fetching
- [x] Verified UI updates
- [x] Checked error handling
- [x] Tested on multiple browsers/devices

## Screenshots

Before:

![image](https://github.com/user-attachments/assets/9ff8909a-a977-4e21-b955-92d3e5f898e2)

After:

![image](https://github.com/user-attachments/assets/38cd6ec4-79ed-47d7-84cf-764c259fd49c)


## Additional Notes
<!-- Any additional information that reviewers should know -->

## Checklist
- [x] Code follows project style guidelines
- [x] API keys and sensitive data are properly protected
- [x] Weather data validation is in place
- [x] Error handling is implemented
- [x] Documentation has been updated
- [x] Tests have been added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Organised the forecast display for clearer separation of weather details, such as time, temperature, wind speed, and more.
- **Style**
  - Enhanced the visual layout by switching to a grid system, improving alignment, spacing, and readability on larger screens.
- **Documentation**
  - Added a changelog entry documenting the visual layout improvement for the 3 Hour Forecast page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->