### PR TITLE
chore: Fixed special character not being detected in PR labeller

### DIFF
--- a/.github/workflows/pr-title-labeler.yml
+++ b/.github/workflows/pr-title-labeler.yml
@@ -93,7 +93,7 @@ jobs:
               let currentTitle = context.payload.pull_request.title;
               
               // Check if current title has any prefix (including non-standard ones)
-              const prefixMatch = currentTitle.match(/^([a-zA-Z]+):\s*(.*)/);
+              const prefixMatch = currentTitle.match(/^([a-zA-Z/]+):\s*(.*)/);
               
               if (prefixMatch) {
                 const titleContent = prefixMatch[2];

--- a/src/resources/CHANGELOG.md
+++ b/src/resources/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Bumped version to 1.1.0
 - Migrated to Vite from deprecated Create React App (CRA)
 - Updated workflow labeller to update ui titles to ui/ux instead of ui
+- Fixed title labeller not recognising '/'
 
 ## 1.0.8 (Minor)
 


### PR DESCRIPTION
## Description
 PR labeller was not recognising that the ui/ux label was already there. this fixes it. 

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Weather data processing
- [ ] Optimisation
- [ ] Security
- [ ] Documentation update
- [x] Chore
- [ ] Other (please describe)

## Changes Made
 
- Added '/' to regex



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced pull request title processing to accurately handle prefixes containing a forward slash.
- **Documentation**
	- Updated the changelog to document the resolution in the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->