### PR TITLE
chore: Ignore linting on pnpm-lock.yaml

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+# Dependency locks
+pnpm-lock.yaml

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,0 @@
-# Dependency locks
-pnpm-lock.yaml

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Dependency locks
+pnpm-lock.yaml

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,16 @@
-# Dependency locks
+# Dependencies
+node_modules
 pnpm-lock.yaml
+
+# Build
+dist
+build
+public
+
+# Misc
+.DS_Store
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,6 +17,7 @@ export default [
       'vite.config.js',
       'postcss.config.js',
       'tailwind.config.js',
+      'pnpm-lock.yaml',
     ],
     languageOptions: {
       ecmaVersion: 'latest',

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Changed light layer to be coloured
 - Moved menuBar to mapElements
 - Added trim to cities in weather submits
-- Added ESLint & Prettier
+- Added ESLint & Prettier (Ignores `pnpm-lock.yaml`)
 
 ---
 


### PR DESCRIPTION
## Description

Ingores linting on `pnpm-lock.yaml`

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Weather data processing
- [ ] Optimisation
- [ ] Security
- [ ] Documentation update
- [x] Chore
- [ ] Other (please describe)

## Changes Made

- Added `pnpm-lock.yaml` to ignore on prettier and eslint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a configuration to exclude certain files and directories from Prettier formatting.
  - Updated ESLint settings to ignore the lockfile.
  - Clarified changelog entry for version 1.1.0 regarding ignored files for ESLint and Prettier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->