### PR TITLE
fix: Removed if in Chore Report Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore_report.yml
+++ b/.github/ISSUE_TEMPLATE/chore_report.yml
@@ -62,11 +62,10 @@ body:
     id: scope-other
     attributes:
       label: Other Scope
-      description: If you selected "Other" above, please specify
+      description: If you selected "Other" in the Scope field above, please specify
       placeholder: e.g., Analytics, Third-party integrations
     validations:
       required: false
-    if: ${{ contains(inputs.scope, 'Other') }}
 
   - type: dropdown
     id: priority

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Convert issue templates to YAML from Markdown for better readability and configuration
 - Updated automatic changelog to wrap package versions in backticks
 - Added exit code to `pr_checks.yml` file
+- Fixed chore report template not being read due to error
 
 ---
 


### PR DESCRIPTION
## Description

Removed extra if statement in chore report template which does not work

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Weather data processing
- [ ] Optimisation
- [ ] Security
- [ ] Documentation update
- [ ] Chore
- [ ] Other (please describe)

## Changes Made

- Removes if statement


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the description text for the "Other Scope" field in the chore report template.
  - Adjusted the display logic for the "Other Scope" input in the chore report template.
  - Updated the changelog to note a fix related to the chore report template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->