### PR TITLE
chore: Option to run PR checker with command

### DIFF
--- a/.github/workflows/check_bot_author.yml
+++ b/.github/workflows/check_bot_author.yml
@@ -1,0 +1,76 @@
+name: Check PR Author Bot Status
+
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        required: true
+        type: string
+        description: 'The pull request number to check'
+      event_type:
+        required: true
+        type: string
+        description: 'The event type (pull_request or issue_comment)'
+    outputs:
+      is_bot:
+        description: 'Whether the PR author is a bot'
+        value: ${{ jobs.check-bot-author.outputs.is_bot }}
+      is_dependabot:
+        description: 'Whether the PR author is specifically Dependabot'
+        value: ${{ jobs.check-bot-author.outputs.is_dependabot }}
+
+jobs:
+  check-bot-author:
+    name: 🔍 Check PR Author
+    runs-on: ubuntu-latest
+    outputs:
+      is_bot: ${{ steps.check-bot.outputs.is_bot }}
+      is_dependabot: ${{ steps.check-bot.outputs.is_dependabot }}
+    steps:
+      - name: Check if PR author is a bot
+        id: check-bot
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            let prAuthor;
+            let prNumber;
+
+            // Handle different event types
+            if (context.payload.pull_request) {
+              // For direct PR events
+              prAuthor = context.payload.pull_request.user.login;
+              prNumber = context.payload.pull_request.number;
+              console.log(`Direct PR event: PR #${prNumber} by ${prAuthor}`);
+            } else {
+              // For comment-triggered events, fetch PR details using the provided number
+              prNumber = ${{ inputs.pr_number }};
+              console.log(`Comment-triggered event: Fetching PR #${prNumber} details`);
+              
+              try {
+                const { data: pr } = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber
+                });
+                prAuthor = pr.user.login;
+                console.log(`Fetched PR author: ${prAuthor}`);
+              } catch (error) {
+                console.error(`Error fetching PR details: ${error.message}`);
+                core.setFailed(`Failed to fetch PR details: ${error.message}`);
+                return;
+              }
+            }
+
+            // Check if the author is a bot (ends with [bot] or is dependabot)
+            const isBot = prAuthor.endsWith('[bot]') || prAuthor.startsWith('dependabot');
+
+            // Check specifically for Dependabot
+            const isDependabot = prAuthor.startsWith('dependabot');
+
+            // Set outputs
+            core.setOutput('is_bot', isBot.toString());
+            core.setOutput('is_dependabot', isDependabot.toString());
+
+            console.log(`PR #${prNumber} Author: ${prAuthor}`);
+            console.log(`Is Bot: ${isBot}`);
+            console.log(`Is Dependabot: ${isDependabot}`);

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -3,6 +3,8 @@ name: Pull Request Checks
 on:
   pull_request:
     types: [opened, reopened, synchronize, edited, ready_for_review, demilestoned]
+  issue_comment:
+    types: [created]
 
 # Add concurrency to cancel in-progress runs on new commits
 concurrency:
@@ -17,9 +19,75 @@ permissions:
 
 jobs:
   #################################################
+  # COMMENT CHECK - For manual trigger via !check
+  #################################################
+  check-manual-trigger:
+    if: ${{ github.event_name == 'issue_comment' }}
+    name: 🔍 Check Manual Trigger
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check-command.outputs.should_run }}
+      pr_number: ${{ steps.get-pr.outputs.pr_number }}
+    steps:
+      - name: Check for command and owner
+        id: check-command
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const comment = context.payload.comment.body;
+            const commenter = context.payload.comment.user.login;
+
+            // Check if the comment contains the command and is from repo owner
+            const isCommand = comment.includes('!check');
+            const isRepoOwner = context.payload.repository.owner.login === commenter;
+
+            const shouldRun = isCommand && isRepoOwner;
+
+            console.log(`Comment: "${comment}"`);
+            console.log(`Commenter: ${commenter}`);
+            console.log(`Is Owner: ${isRepoOwner}`);
+            console.log(`Is Command: ${isCommand}`);
+            console.log(`Should Run: ${shouldRun}`);
+
+            core.setOutput('should_run', shouldRun.toString());
+
+            // Comment with acknowledgment if it's the command
+            if (isCommand) {
+              if (isRepoOwner) {
+                await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: '✅ PR check workflow manually triggered by repository owner.'
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: '⚠️ Only repository owners can trigger the PR check workflow manually.'
+                });
+              }
+            }
+
+      - name: Get PR number
+        id: get-pr
+        if: ${{ steps.check-command.outputs.should_run == 'true' }}
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            // Comment is on a PR issue
+            const prNumber = context.issue.number;
+            console.log(`PR Number: ${prNumber}`);
+            core.setOutput('pr_number', prNumber);
+
+  #################################################
   # INITIAL CHECK - Author detection
   #################################################
   initial-author-check:
+    needs: [check-manual-trigger]
+    # Run if this is a PR event OR if it's a manual trigger and should_run is true
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && needs.check-manual-trigger.outputs.should_run == 'true') }}
     name: 🔍 Initial PR Author Check
     runs-on: ubuntu-latest
     outputs:
@@ -31,7 +99,23 @@ jobs:
         uses: actions/github-script@v7.0.1
         with:
           script: |
-            const prAuthor = context.payload.pull_request.user.login;
+            // Handle both direct PR events and comment-triggered events
+            let prAuthor;
+            let prNumber;
+
+            if (context.eventName === 'pull_request') {
+              prAuthor = context.payload.pull_request.user.login;
+              prNumber = context.payload.pull_request.number;
+            } else {
+              // For comment events, we need to fetch the PR details
+              prNumber = ${{ needs.check-manual-trigger.outputs.pr_number }};
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              prAuthor = pr.user.login;
+            }
 
             // Check if the author is a bot (ends with [bot] or is dependabot)
             const isBot = prAuthor.endsWith('[bot]') || prAuthor.startsWith('dependabot');

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -22,7 +22,7 @@ jobs:
   # COMMENT CHECK - For manual trigger via !check
   #################################################
   check-manual-trigger:
-    if: ${{ github.event_name == 'issue_comment' }}
+    if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request }}
     name: 🔍 Check Manual Trigger
     runs-on: ubuntu-latest
     outputs:
@@ -38,7 +38,8 @@ jobs:
             const commenter = context.payload.comment.user.login;
 
             // Check if the comment contains the command and is from repo owner
-            const isCommand = comment.includes('!check');
+            // More strict matching: must be at beginning of line and a standalone word
+            const isCommand = /^!check\b/.test(comment.trim());
             const isRepoOwner = context.payload.repository.owner.login === commenter;
 
             const shouldRun = isCommand && isRepoOwner;
@@ -87,32 +88,10 @@ jobs:
   initial-author-check-pr:
     if: ${{ github.event_name == 'pull_request' }}
     name: 🔍 Initial PR Author Check
-    runs-on: ubuntu-latest
-    outputs:
-      is_bot: ${{ steps.check-bot.outputs.is_bot }}
-      is_dependabot: ${{ steps.check-bot.outputs.is_dependabot }}
-    steps:
-      - name: Check if PR author is a bot
-        id: check-bot
-        uses: actions/github-script@v7.0.1
-        with:
-          script: |
-            const prAuthor = context.payload.pull_request.user.login;
-            const prNumber = context.payload.pull_request.number;
-
-            // Check if the author is a bot (ends with [bot] or is dependabot)
-            const isBot = prAuthor.endsWith('[bot]') || prAuthor.startsWith('dependabot');
-
-            // Check specifically for Dependabot
-            const isDependabot = prAuthor.startsWith('dependabot');
-
-            // Set outputs
-            core.setOutput('is_bot', isBot.toString());
-            core.setOutput('is_dependabot', isDependabot.toString());
-
-            console.log(`PR Author: ${prAuthor}`);
-            console.log(`Is Bot: ${isBot}`);
-            console.log(`Is Dependabot: ${isDependabot}`);
+    uses: ./.github/workflows/check_bot_author.yml
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      event_type: 'pull_request'
 
   #################################################
   # INITIAL CHECK - Author detection for manual triggers
@@ -121,38 +100,10 @@ jobs:
     needs: [check-manual-trigger]
     if: ${{ github.event_name == 'issue_comment' && needs.check-manual-trigger.outputs.should_run == 'true' }}
     name: 🔍 Initial PR Author Check (Manual)
-    runs-on: ubuntu-latest
-    outputs:
-      is_bot: ${{ steps.check-bot.outputs.is_bot }}
-      is_dependabot: ${{ steps.check-bot.outputs.is_dependabot }}
-    steps:
-      - name: Check if PR author is a bot
-        id: check-bot
-        uses: actions/github-script@v7.0.1
-        with:
-          script: |
-            // For comment events, we need to fetch the PR details
-            const prNumber = ${{ needs.check-manual-trigger.outputs.pr_number }};
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber
-            });
-            const prAuthor = pr.user.login;
-
-            // Check if the author is a bot (ends with [bot] or is dependabot)
-            const isBot = prAuthor.endsWith('[bot]') || prAuthor.startsWith('dependabot');
-
-            // Check specifically for Dependabot
-            const isDependabot = prAuthor.startsWith('dependabot');
-
-            // Set outputs
-            core.setOutput('is_bot', isBot.toString());
-            core.setOutput('is_dependabot', isDependabot.toString());
-
-            console.log(`PR Author: ${prAuthor}`);
-            console.log(`Is Bot: ${isBot}`);
-            console.log(`Is Dependabot: ${isDependabot}`);
+    uses: ./.github/workflows/check_bot_author.yml
+    with:
+      pr_number: ${{ needs.check-manual-trigger.outputs.pr_number }}
+      event_type: 'issue_comment'
 
   #################################################
   # CHANGELOG CHECKS

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -82,12 +82,10 @@ jobs:
             core.setOutput('pr_number', prNumber);
 
   #################################################
-  # INITIAL CHECK - Author detection
+  # INITIAL CHECK - Author detection for PR events
   #################################################
-  initial-author-check:
-    needs: [check-manual-trigger]
-    # Run if this is a PR event OR if it's a manual trigger and should_run is true
-    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && needs.check-manual-trigger.outputs.should_run == 'true') }}
+  initial-author-check-pr:
+    if: ${{ github.event_name == 'pull_request' }}
     name: 🔍 Initial PR Author Check
     runs-on: ubuntu-latest
     outputs:
@@ -99,23 +97,48 @@ jobs:
         uses: actions/github-script@v7.0.1
         with:
           script: |
-            // Handle both direct PR events and comment-triggered events
-            let prAuthor;
-            let prNumber;
+            const prAuthor = context.payload.pull_request.user.login;
+            const prNumber = context.payload.pull_request.number;
 
-            if (context.eventName === 'pull_request') {
-              prAuthor = context.payload.pull_request.user.login;
-              prNumber = context.payload.pull_request.number;
-            } else {
-              // For comment events, we need to fetch the PR details
-              prNumber = ${{ needs.check-manual-trigger.outputs.pr_number }};
-              const { data: pr } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber
-              });
-              prAuthor = pr.user.login;
-            }
+            // Check if the author is a bot (ends with [bot] or is dependabot)
+            const isBot = prAuthor.endsWith('[bot]') || prAuthor.startsWith('dependabot');
+
+            // Check specifically for Dependabot
+            const isDependabot = prAuthor.startsWith('dependabot');
+
+            // Set outputs
+            core.setOutput('is_bot', isBot.toString());
+            core.setOutput('is_dependabot', isDependabot.toString());
+
+            console.log(`PR Author: ${prAuthor}`);
+            console.log(`Is Bot: ${isBot}`);
+            console.log(`Is Dependabot: ${isDependabot}`);
+
+  #################################################
+  # INITIAL CHECK - Author detection for manual triggers
+  #################################################
+  initial-author-check-manual:
+    needs: [check-manual-trigger]
+    if: ${{ github.event_name == 'issue_comment' && needs.check-manual-trigger.outputs.should_run == 'true' }}
+    name: 🔍 Initial PR Author Check (Manual)
+    runs-on: ubuntu-latest
+    outputs:
+      is_bot: ${{ steps.check-bot.outputs.is_bot }}
+      is_dependabot: ${{ steps.check-bot.outputs.is_dependabot }}
+    steps:
+      - name: Check if PR author is a bot
+        id: check-bot
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            // For comment events, we need to fetch the PR details
+            const prNumber = ${{ needs.check-manual-trigger.outputs.pr_number }};
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+            const prAuthor = pr.user.login;
 
             // Check if the author is a bot (ends with [bot] or is dependabot)
             const isBot = prAuthor.endsWith('[bot]') || prAuthor.startsWith('dependabot');
@@ -136,8 +159,13 @@ jobs:
   #################################################
   changelog-update-dependabot:
     name: 📝 Update Changelog (Dependabot)
-    needs: initial-author-check
-    if: ${{ needs.initial-author-check.outputs.is_dependabot == 'true' }}
+    needs: [initial-author-check-pr, initial-author-check-manual]
+    if: |
+      always() &&
+      (
+        (needs.initial-author-check-pr.result == 'success' && needs.initial-author-check-pr.outputs.is_dependabot == 'true') || 
+        (needs.initial-author-check-manual.result == 'success' && needs.initial-author-check-manual.outputs.is_dependabot == 'true')
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -248,9 +276,13 @@ jobs:
 
   changelog-check-user:
     name: 📋 Check Changelog (User PR)
-    needs: initial-author-check
-    # Skip if it's a bot PR
-    if: ${{ needs.initial-author-check.outputs.is_bot == 'false' }}
+    needs: [initial-author-check-pr, initial-author-check-manual]
+    if: |
+      always() &&
+      (
+        (needs.initial-author-check-pr.result == 'success' && needs.initial-author-check-pr.outputs.is_bot == 'false') || 
+        (needs.initial-author-check-manual.result == 'success' && needs.initial-author-check-manual.outputs.is_bot == 'false')
+      )
     runs-on: ubuntu-latest
     outputs:
       has_changes: ${{ steps.changelog-check.outputs.changed }}
@@ -265,8 +297,13 @@ jobs:
 
   changelog-enforce-user:
     name: ✅ Enforce Changelog (User PR)
-    needs: [initial-author-check, changelog-check-user]
-    if: ${{ needs.initial-author-check.outputs.is_bot == 'false' }}
+    needs: [initial-author-check-pr, initial-author-check-manual, changelog-check-user]
+    if: |
+      always() &&
+      (
+        (needs.initial-author-check-pr.result == 'success' && needs.initial-author-check-pr.outputs.is_bot == 'false') || 
+        (needs.initial-author-check-manual.result == 'success' && needs.initial-author-check-manual.outputs.is_bot == 'false')
+      )
     runs-on: ubuntu-latest
     outputs:
       should_block: ${{ steps.check-status.outputs.should_block }}
@@ -302,8 +339,13 @@ jobs:
   #################################################
   # For non-bot PRs - runs immediately
   quality-lint-format-user:
-    needs: [initial-author-check]
-    if: ${{ needs.initial-author-check.outputs.is_bot == 'false' }}
+    needs: [initial-author-check-pr, initial-author-check-manual]
+    if: |
+      always() &&
+      (
+        (needs.initial-author-check-pr.result == 'success' && needs.initial-author-check-pr.outputs.is_bot == 'false') || 
+        (needs.initial-author-check-manual.result == 'success' && needs.initial-author-check-manual.outputs.is_bot == 'false')
+      )
     uses: ./.github/workflows/lint_format.yml
     with:
       job-name: '🧹 Code Quality Checks'
@@ -311,8 +353,13 @@ jobs:
   # For bot PRs - waits for changelog update to finish
   quality-lint-format-bot:
     # Wait for changelog update to complete for bot PRs
-    needs: [initial-author-check, changelog-update-dependabot]
-    if: ${{ needs.initial-author-check.outputs.is_bot == 'true' }}
+    needs: [initial-author-check-pr, initial-author-check-manual, changelog-update-dependabot]
+    if: |
+      always() &&
+      (
+        (needs.initial-author-check-pr.result == 'success' && needs.initial-author-check-pr.outputs.is_bot == 'true') || 
+        (needs.initial-author-check-manual.result == 'success' && needs.initial-author-check-manual.outputs.is_bot == 'true')
+      )
     uses: ./.github/workflows/lint_format.yml
     with:
       job-name: '🧹 Code Quality Checks (Bot PR)'
@@ -323,7 +370,8 @@ jobs:
   metadata-milestone-check:
     name: 🏷️ PR Milestone Check
     needs:
-      - initial-author-check
+      - initial-author-check-pr
+      - initial-author-check-manual
       - quality-lint-format-user
       - quality-lint-format-bot
     # This ensures it only needs one of the two lint jobs to complete based on PR author type
@@ -398,7 +446,8 @@ jobs:
   final-status:
     name: 🚦 Final Status Check
     needs:
-      - initial-author-check
+      - initial-author-check-pr
+      - initial-author-check-manual
       - quality-lint-format-user
       - quality-lint-format-bot
       - metadata-milestone-check
@@ -411,8 +460,24 @@ jobs:
       - name: Set job status variables
         id: set-status
         run: |
-          IS_BOT="${{ needs.initial-author-check.outputs.is_bot }}"
-          echo "is_bot=$IS_BOT" >> $GITHUB_OUTPUT
+          # Determine if this is a bot PR regardless of trigger type
+          IS_BOT_PR="false"
+          IS_BOT_MANUAL="false"
+
+          if [[ "${{ needs.initial-author-check-pr.result }}" == "success" ]]; then
+            IS_BOT_PR="${{ needs.initial-author-check-pr.outputs.is_bot }}"
+          fi
+
+          if [[ "${{ needs.initial-author-check-manual.result }}" == "success" ]]; then
+            IS_BOT_MANUAL="${{ needs.initial-author-check-manual.outputs.is_bot }}"
+          fi
+
+          # If either path determined it's a bot, set is_bot=true
+          if [[ "$IS_BOT_PR" == "true" || "$IS_BOT_MANUAL" == "true" ]]; then
+            echo "is_bot=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_bot=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Generate status report
         run: |
@@ -420,8 +485,17 @@ jobs:
           echo ""
           echo "| Check | Status | Result |"
           echo "|-------|--------|--------|"
-          echo "| 🔍 Initial Author Check | ${{ needs.initial-author-check.result }} | PR is by ${{ needs.initial-author-check.outputs.is_bot == 'true' && 'bot' || 'user' }} |"
 
+          # Check which trigger path was used
+          if [[ "${{ needs.initial-author-check-pr.result }}" == "success" ]]; then
+            echo "| 🔍 Initial Author Check (PR) | ${{ needs.initial-author-check-pr.result }} | PR is by ${{ needs.initial-author-check-pr.outputs.is_bot == 'true' && 'bot' || 'user' }} |"
+          fi
+
+          if [[ "${{ needs.initial-author-check-manual.result }}" == "success" ]]; then
+            echo "| 🔍 Initial Author Check (Manual) | ${{ needs.initial-author-check-manual.result }} | PR is by ${{ needs.initial-author-check-manual.outputs.is_bot == 'true' && 'bot' || 'user' }} |"
+          fi
+
+          # Rest remains the same
           if [[ "${{ steps.set-status.outputs.is_bot }}" == "true" ]]; then
             echo "| 📝 Update Changelog (Bot) | ${{ needs.changelog-update-dependabot.result }} | ${{ needs.changelog-update-dependabot.outputs.changelog_updated == 'true' && 'Updated' || 'Not applicable' }} |"
             echo "| 🧹 Code Quality (Bot) | ${{ needs.quality-lint-format-bot.result }} | - |"
@@ -440,8 +514,12 @@ jobs:
           echo "⛔ One or more checks failed - blocking merge"
 
           # List which checks failed
-          if [[ "${{ needs.initial-author-check.result }}" == "failure" ]]; then
-            echo "- ❌ Initial author check failed"
+          if [[ "${{ needs.initial-author-check-pr.result }}" == "failure" ]]; then
+            echo "- ❌ Initial author check (PR) failed"
+          fi
+
+          if [[ "${{ needs.initial-author-check-manual.result }}" == "failure" ]]; then
+            echo "- ❌ Initial author check (Manual) failed"
           fi
 
           if [[ "${{ needs.metadata-milestone-check.result }}" == "failure" ]]; then

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Updated automatic changelog to wrap package versions in backticks
 - Fixed chore report template not being read due to error
 - Fixes issue with Dependabot PRs not getting status from PR Checks workflow
+- Added option to run PR check workflow with command by repo owner
 
 ---
 


### PR DESCRIPTION
## Description

Added option to run PR Checker with !check but only by repo owner (a.k.a me)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Weather data processing
- [ ] Optimisation
- [ ] Security
- [ ] Documentation update
- [x] Chore
- [ ] Other (please describe)

## Changes Made

- Adjusted workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Repository owners can now manually trigger pull request checks by commenting `!check` on a pull request.
	- Enhanced bot author detection to support manual triggers and pull request events separately.
- **Documentation**
	- Updated changelog to document the new manual trigger option for pull request checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->